### PR TITLE
feat(components): WB2-2294, creating ModuleImage

### DIFF
--- a/src/framework/components/picture/module-image/component.tsx
+++ b/src/framework/components/picture/module-image/component.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { ImageProps, View } from 'react-native';
+
+import { Fade, Placeholder, PlaceholderMedia } from 'rn-placeholder';
+
+import styles from './styles';
+import { ImageFallbackProps, ImageLoaderProps, ImageLoadingState, ModuleImageProps } from './types';
+
+import theme from '~/app/theme';
+import { Icon, Svg } from '~/framework/components/picture';
+import { Image } from '~/framework/util/media';
+
+const DEFAULT_MODULE_CONFIG: Required<ModuleImageProps['moduleConfig']> = {
+  displayColor: {
+    pale: theme.palette.grey.pearl,
+    regular: theme.palette.grey.grey,
+  },
+  displayPicture: {
+    name: 'image-not-found',
+    type: 'Svg',
+  },
+};
+
+const DEFAULT_ICON_SIZE = '58%';
+
+const ImageFallback: React.FC<ImageFallbackProps> = ({
+  iconSize,
+  imageProps,
+  moduleConfig: {
+    displayColor = DEFAULT_MODULE_CONFIG.displayColor,
+    displayPicture = DEFAULT_MODULE_CONFIG.displayPicture,
+  } = DEFAULT_MODULE_CONFIG,
+}) => {
+  const svgContainerStyle = React.useMemo(
+    () =>
+      displayPicture.type === 'Svg' ? [styles.moduleImage, { backgroundColor: displayColor?.pale }, imageProps.style] : undefined,
+    [displayColor?.pale, imageProps.style, displayPicture.type],
+  );
+  const imageContainerStyle = React.useMemo(
+    () => (displayPicture.type === 'Image' ? [styles.moduleImage, imageProps.style] : undefined),
+    [displayPicture.type, imageProps.style],
+  );
+
+  switch (displayPicture.type) {
+    case 'Svg':
+      return (
+        <View style={svgContainerStyle}>
+          <Svg {...displayPicture} height={iconSize ?? DEFAULT_ICON_SIZE} width={iconSize ?? DEFAULT_ICON_SIZE} />
+        </View>
+      );
+    case 'Icon':
+      return <Icon {...displayPicture} />;
+    case 'Image':
+      return (
+        <View style={imageContainerStyle}>
+          <Image {...displayPicture} />
+        </View>
+      );
+    default:
+      return null;
+  }
+};
+
+const ImageLoader: React.FC<ImageLoaderProps> = ({ imageProps }) => {
+  const imageLoaderStyle = React.useMemo(() => [styles.moduleImage, imageProps.style], [imageProps.style]);
+
+  return (
+    <Placeholder Animation={Fade} style={imageLoaderStyle}>
+      <PlaceholderMedia style={styles.imageLoader} />
+    </Placeholder>
+  );
+};
+
+const ModuleImage: React.FC<ModuleImageProps> = ({ iconSize, moduleConfig, onError, onLoad, ...props }) => {
+  // Restore loading state when source changes
+  const prevSource = React.useRef(props.source);
+  const [imageLoadingState, setImageLoadingState] = React.useState<ImageLoadingState>(ImageLoadingState.Loading);
+  if (prevSource.current !== props.source) {
+    setImageLoadingState(ImageLoadingState.Loading);
+    prevSource.current = props.source;
+  }
+
+  const onImageLoadSuccess = React.useCallback<NonNullable<ImageProps['onLoad']>>(
+    e => {
+      setImageLoadingState(ImageLoadingState.Success);
+      onLoad?.(e);
+    },
+    [onLoad],
+  );
+  const onImageLoadError = React.useCallback<NonNullable<ImageProps['onError']>>(
+    e => {
+      setImageLoadingState(ImageLoadingState.Error);
+      onError?.(e);
+    },
+    [onError],
+  );
+
+  return (
+    <View style={styles.moduleImageContainer}>
+      {imageLoadingState === ImageLoadingState.Error ? (
+        <ImageFallback moduleConfig={moduleConfig} imageProps={props} iconSize={iconSize} />
+      ) : (
+        <>
+          <Image {...props} onLoad={onImageLoadSuccess} onError={onImageLoadError} />
+          {imageLoadingState === ImageLoadingState.Loading && <ImageLoader imageProps={props} />}
+        </>
+      )}
+    </View>
+  );
+};
+
+export default ModuleImage;

--- a/src/framework/components/picture/module-image/index.tsx
+++ b/src/framework/components/picture/module-image/index.tsx
@@ -1,0 +1,3 @@
+import ModuleImage from './component';
+
+export default ModuleImage;

--- a/src/framework/components/picture/module-image/styles.ts
+++ b/src/framework/components/picture/module-image/styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native';
+
+import { UI_SIZES } from '~/framework/components/constants';
+
+export default StyleSheet.create({
+  imageLoader: {
+    height: '100%',
+    width: '100%',
+  },
+  moduleImage: {
+    alignItems: 'center',
+    borderRadius: UI_SIZES.radius.medium,
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  moduleImageContainer: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/framework/components/picture/module-image/types.ts
+++ b/src/framework/components/picture/module-image/types.ts
@@ -1,0 +1,28 @@
+import { ImageProps } from 'react-native';
+
+import { SvgProps } from 'react-native-svg';
+
+import { PictureProps } from '~/framework/components/picture';
+import { AnyNavigableModuleConfig } from '~/framework/util/moduleTool';
+
+export type ImageFallbackProps = Partial<PictureProps> &
+  Pick<ModuleImageProps, 'iconSize' | 'moduleConfig'> & {
+    imageProps: ImageProps;
+  };
+
+export type ImageLoaderProps = Pick<ImageFallbackProps, 'imageProps'>;
+
+export const enum ImageLoadingState {
+  Loading,
+  Success,
+  Error,
+}
+
+export type ModuleConfigForFallbackImage = Pick<AnyNavigableModuleConfig, 'displayPicture'> & {
+  displayColor?: Pick<Required<AnyNavigableModuleConfig>['displayColor'], 'pale' | 'regular'>;
+};
+
+export type ModuleImageProps = ImageProps & {
+  moduleConfig: ModuleConfigForFallbackImage;
+  iconSize?: SvgProps['width'];
+};

--- a/src/framework/modules/wiki/screens/home/index.ts
+++ b/src/framework/modules/wiki/screens/home/index.ts
@@ -3,4 +3,3 @@ import WikiHomeScreen from './screen';
 export default WikiHomeScreen;
 export { computeNavBar } from './screen';
 export type { WikiHomeScreenNavParams, WikiHomeScreenProps } from './types';
-


### PR DESCRIPTION
Adding ModuleImage component handling 3 cases : 
- displays a loader on image load
- displays the image once loaded
- displays a fallback svg icon representing the current module icon or a empty state icon if none available